### PR TITLE
Issue 19 :: refactor color scheme

### DIFF
--- a/src/fractals/color_scheme.rs
+++ b/src/fractals/color_scheme.rs
@@ -1,98 +1,10 @@
 use ::image::Rgb;
-use core::str::FromStr;
 
 use super::escape_time::Iteration;
-use super::gray::gray;
-use super::warp_pov::warp_pov;
 
 #[derive(Debug, PartialEq)]
-pub enum ColorScheme {
-  BlackOnWhite,
-  Blue,
-  Gray,
-  Green,
-  Random,
-  Red,
-  WhiteOnBlack,
-}
+pub struct Random {}
 
-impl ColorScheme {
-  pub fn color(&self, iter: Iteration) -> Rgb<u8> {
-    match self {
-      ColorScheme::BlackOnWhite => gray(self, iter),
-      ColorScheme::Blue => warp_pov(self, iter),
-      ColorScheme::Gray => gray(self, iter),
-      ColorScheme::Green => warp_pov(self, iter),
-      ColorScheme::Red => warp_pov(self, iter),
-      ColorScheme::WhiteOnBlack => gray(self, iter),
-      &_ => Err(()),
-    }
-    .unwrap()
-  }
-}
-
-impl FromStr for ColorScheme {
-  type Err = ();
-
-  fn from_str(s: &str) -> Result<ColorScheme, ()> {
-    match s {
-      "BlackOnWhite" => Ok(ColorScheme::BlackOnWhite),
-      "Blue" => Ok(ColorScheme::Blue),
-      "Gray" => Ok(ColorScheme::Gray),
-      "Green" => Ok(ColorScheme::Green),
-      "Random" => Ok(ColorScheme::Random),
-      "Red" => Ok(ColorScheme::Red),
-      "WhiteOnBlack" => Ok(ColorScheme::WhiteOnBlack),
-      _ => Err(()),
-    }
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use ::image::Pixel;
-  use proptest::prelude::*;
-
-  fn inside(iterations: u32) -> Iteration {
-    Iteration::Inside {
-      iterations: iterations,
-    }
-  }
-
-  fn outside(iterations: u32) -> Iteration {
-    Iteration::Outside {
-      iterations: iterations,
-    }
-  }
-
-  proptest! {
-    #[test]
-    fn gray_colors_have_same_rgb_outside(iterations in 0u32..1024, index in 0usize..2)  {
-      let colors_schemes = [
-        ColorScheme::BlackOnWhite,
-        ColorScheme::Gray,
-        ColorScheme::WhiteOnBlack
-      ];
-      let color_scheme = &colors_schemes[index];
-      let color = color_scheme.color(outside(iterations));
-      let channels = color.channels();
-      prop_assert_eq!(channels[0], channels[1]);
-      prop_assert_eq!(channels[0], channels[2]);
-    }
-
-    #[test]
-    fn gray_colors_have_same_rgb_inside(iterations in 0u32..1024, index in 0usize..2)  {
-      let colors_schemes = [
-        ColorScheme::BlackOnWhite,
-        ColorScheme::Gray,
-        ColorScheme::WhiteOnBlack
-      ];
-      let color_scheme = &colors_schemes[index];
-      let color = color_scheme.color(inside(iterations));
-      let channels = color.channels();
-      prop_assert_eq!(channels[0], channels[1]);
-      prop_assert_eq!(channels[0], channels[2]);
-    }
-  }
+pub trait ColorScheme: std::fmt::Debug {
+  fn color(&self, iter: Iteration) -> Rgb<u8>;
 }

--- a/src/fractals/escape_time.rs
+++ b/src/fractals/escape_time.rs
@@ -2,50 +2,50 @@ use num_complex::Complex;
 
 #[derive(Debug, PartialEq)]
 pub enum Iteration {
-  Inside { iterations: u32 },
-  Outside { iterations: u32 },
+    Inside { iterations: u32 },
+    Outside { iterations: u32 },
 }
 
 pub fn iterate(c: &Complex<f64>) -> Iteration {
-  let mut z = Complex::new(0.0, 0.0);
-  let mut iter = 0;
+    let mut z = Complex::new(0.0, 0.0);
+    let mut iter = 0;
 
-  while z.norm_sqr() < 4.0 && iter < 512 {
-    z = z * z + c;
-    iter = iter + 1;
-  }
-  if iter >= 512 {
-    Iteration::Inside { iterations: iter }
-  } else {
-    Iteration::Outside { iterations: iter }
-  }
+    while z.norm_sqr() < 4.0 && iter < 512 {
+        z = z * z + c;
+        iter = iter + 1;
+    }
+    if iter >= 512 {
+        Iteration::Inside { iterations: iter }
+    } else {
+        Iteration::Outside { iterations: iter }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::*;
 
-  #[test]
-  fn test_iterate_inside() {
-    assert_eq!(
-      Iteration::Inside { iterations: 512 },
-      iterate(&Complex::new(0.0, 0.0))
-    );
-    assert_eq!(
-      Iteration::Inside { iterations: 512 },
-      iterate(&Complex::new(0.2, 0.5))
-    );
-  }
+    #[test]
+    fn test_iterate_inside() {
+        assert_eq!(
+            Iteration::Inside { iterations: 512 },
+            iterate(&Complex::new(0.0, 0.0))
+        );
+        assert_eq!(
+            Iteration::Inside { iterations: 512 },
+            iterate(&Complex::new(0.2, 0.5))
+        );
+    }
 
-  #[test]
-  fn test_iterate_outside() {
-    assert_eq!(
-      Iteration::Outside { iterations: 1 },
-      iterate(&Complex::new(2.0, 2.0))
-    );
-    assert_eq!(
-      Iteration::Outside { iterations: 12 },
-      iterate(&Complex::new(0.2, 0.6))
-    );
-  }
+    #[test]
+    fn test_iterate_outside() {
+        assert_eq!(
+            Iteration::Outside { iterations: 1 },
+            iterate(&Complex::new(2.0, 2.0))
+        );
+        assert_eq!(
+            Iteration::Outside { iterations: 12 },
+            iterate(&Complex::new(0.2, 0.6))
+        );
+    }
 }

--- a/src/fractals/gray.rs
+++ b/src/fractals/gray.rs
@@ -3,113 +3,138 @@ use ::image::Rgb;
 use super::color_scheme::ColorScheme;
 use super::escape_time::Iteration;
 
-pub fn gray(color_scheme: &ColorScheme, iter: Iteration) -> Result<Rgb<u8>, ()> {
-  match color_scheme {
-    ColorScheme::BlackOnWhite => match iter {
-      Iteration::Inside { iterations: _ } => Ok(Rgb([0, 0, 0])),
-      Iteration::Outside { iterations: _ } => Ok(Rgb([255, 255, 255])),
-    },
-    ColorScheme::Gray => match iter {
-      Iteration::Inside { iterations: _ } => Ok(Rgb([0, 0, 0])),
-      Iteration::Outside { iterations } => Ok(sqrt_scale(iterations)),
-    },
-    ColorScheme::WhiteOnBlack => match iter {
-      Iteration::Inside { iterations: _ } => Ok(Rgb([255, 255, 255])),
-      Iteration::Outside { iterations: _ } => Ok(Rgb([0, 0, 0])),
-    },
-    &_ => Err(()),
-  }
+#[derive(Debug, PartialEq)]
+pub struct BlackOnWhite {}
+
+impl ColorScheme for BlackOnWhite {
+    fn color(&self, iter: Iteration) -> Rgb<u8> {
+        match iter {
+            Iteration::Inside { .. } => Rgb([0, 0, 0]),
+            Iteration::Outside { .. } => Rgb([255, 255, 255]),
+        }
+    }
 }
 
-fn sqrt_scale(iterations: u32) -> Rgb<u8> {
-  let factor = (iterations as f64 / 512.0).sqrt();
-  let intensity = (factor * 255.0) as u8;
-  Rgb([intensity, intensity, intensity])
+#[derive(Debug, PartialEq)]
+pub struct Gray {}
+
+impl ColorScheme for Gray {
+    fn color(&self, iter: Iteration) -> Rgb<u8> {
+        match iter {
+            Iteration::Inside { .. } => Rgb([0, 0, 0]),
+            Iteration::Outside { iterations } => gray_scale(iterations),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct WhiteOnBlack {}
+
+impl ColorScheme for WhiteOnBlack {
+    fn color(&self, iter: Iteration) -> Rgb<u8> {
+        match iter {
+            Iteration::Inside { .. } => Rgb([255, 255, 255]),
+            Iteration::Outside { .. } => Rgb([0, 0, 0]),
+        }
+    }
+}
+
+fn gray_scale(iterations: u32) -> Rgb<u8> {
+    let factor = (iterations as f64 / 512.0).sqrt();
+    let intensity = (factor * 255.0) as u8;
+    Rgb([intensity, intensity, intensity])
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-
-  fn inside(iterations: u32) -> Iteration {
-    Iteration::Inside {
-      iterations: iterations,
-    }
-  }
-
-  fn outside(iterations: u32) -> Iteration {
-    Iteration::Outside {
-      iterations: iterations,
-    }
-  }
-
-  mod black_on_white {
-    use super::super::*;
     use super::*;
-    use proptest::prelude::*;
 
-    proptest! {
-      #[test]
-      fn inside_always_black(iterations in 0u32..1024)  {
-        let color = gray(&ColorScheme::BlackOnWhite, outside(iterations));
-        prop_assert_eq!(Ok(Rgb([255, 255, 255])), color);
-      }
-
-      #[test]
-      fn outside_always_white(iterations in 0u32..1024)  {
-        let color = gray(&ColorScheme::BlackOnWhite, inside(iterations));
-            prop_assert_eq!(Ok(Rgb([0, 0, 0])), color);
-      }
-    }
-  }
-
-  mod gray {
-    use super::super::*;
-    use super::*;
-    use ::image::Pixel;
-    use proptest::prelude::*;
-
-    proptest! {
-      #[test]
-      fn inside_always_black(iterations in 0u32..1024)  {
-        let color = gray(&ColorScheme::Gray, inside(iterations));
-        prop_assert_eq!(Ok(Rgb([0, 0, 0])), color);
-      }
+    fn inside(iterations: u32) -> Iteration {
+        Iteration::Inside {
+            iterations: iterations,
+        }
     }
 
-    #[test]
-    fn outside_scaled_gray() {
-      let color_result = gray(&ColorScheme::Gray, outside(128)).unwrap();
-      let channels = color_result.channels();
-      assert_eq!(127, channels[0]);
-      assert_eq!(127, channels[1]);
-      assert_eq!(127, channels[2]);
-
-      let color_result = gray(&ColorScheme::Gray, outside(64)).unwrap();
-      let channels = color_result.channels();
-      assert_eq!(90, channels[0]);
-      assert_eq!(90, channels[1]);
-      assert_eq!(90, channels[2]);
+    fn outside(iterations: u32) -> Iteration {
+        Iteration::Outside {
+            iterations: iterations,
+        }
     }
-  }
 
-  mod white_on_black {
-    use super::super::*;
-    use super::*;
-    use proptest::prelude::*;
+    mod black_on_white {
+        use super::super::*;
+        use super::*;
+        use proptest::prelude::*;
 
-    proptest! {
-      #[test]
-      fn inside_always_white(iterations in 0u32..1024)  {
-        let color = gray(&ColorScheme::WhiteOnBlack, outside(iterations));
-        prop_assert_eq!(Ok(Rgb([0, 0, 0])), color);
-      }
+        proptest! {
+          #[test]
+          fn inside_always_black(iterations in 0u32..1024)  {
+            let cs = BlackOnWhite {};
+            let color = cs.color(outside(iterations));
+            prop_assert_eq!(Rgb([255, 255, 255]), color);
+          }
 
-      #[test]
-      fn outside_always_black(iterations in 0u32..1024)  {
-        let color = gray(&ColorScheme::WhiteOnBlack, inside(iterations));
-            prop_assert_eq!(Ok(Rgb([255, 255, 255])), color);
-      }
+          #[test]
+          fn outside_always_white(iterations in 0u32..1024)  {
+            let cs = BlackOnWhite {};
+            let color = cs.color(inside(iterations));
+                prop_assert_eq!(Rgb([0, 0, 0]), color);
+          }
+        }
     }
-  }
+
+    mod gray {
+        use super::super::*;
+        use super::*;
+        use ::image::Pixel;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn inside_always_black(iterations in 0u32..1024)  {
+                let cs = Gray {};
+                let color = cs.color(inside(iterations));
+                prop_assert_eq!(Rgb([0, 0, 0]), color);
+            }
+        }
+
+        #[test]
+        fn outside_scaled_gray() {
+            let cs = Gray {};
+
+            let color = cs.color(outside(128));
+            let channels = color.channels();
+            assert_eq!(127, channels[0]);
+            assert_eq!(127, channels[1]);
+            assert_eq!(127, channels[2]);
+
+            let color = cs.color(outside(64));
+            let channels = color.channels();
+            assert_eq!(90, channels[0]);
+            assert_eq!(90, channels[1]);
+            assert_eq!(90, channels[2]);
+        }
+    }
+
+    mod white_on_black {
+        use super::super::*;
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn inside_always_white(iterations in 0u32..1024)  {
+                let cs = WhiteOnBlack {};
+                let color = cs.color(inside(iterations));
+                prop_assert_eq!(Rgb([255, 255, 255]), color);
+            }
+
+            #[test]
+            fn outside_always_black(iterations in 0u32..1024)  {
+                let cs = WhiteOnBlack {};
+                let color = cs.color(outside(iterations));
+                prop_assert_eq!(Rgb([0, 0, 0]), color);
+            }
+        }
+    }
 }

--- a/src/fractals/image.rs
+++ b/src/fractals/image.rs
@@ -1,101 +1,101 @@
-use num_complex::Complex;
 use super::size::Size;
+use num_complex::Complex;
 
 #[derive(Debug, PartialEq)]
 pub struct Image {
-  pub input_filename: String,
-  pub output_filename: String,
-  pub size: Size,
-  pub upper_left: Complex<f64>,
-  pub lower_right: Complex<f64>,
+    pub input_filename: String,
+    pub output_filename: String,
+    pub size: Size,
+    pub upper_left: Complex<f64>,
+    pub lower_right: Complex<f64>,
 }
 
 impl Image {
-  pub fn view_width(&self) -> f64 {
-    (self.upper_left.re - self.lower_right.re).abs()
-  }
-  pub fn view_height(&self) -> f64 {
-    (self.lower_right.im - self.upper_left.im).abs()
-  }
+    pub fn view_width(&self) -> f64 {
+        (self.upper_left.re - self.lower_right.re).abs()
+    }
+    pub fn view_height(&self) -> f64 {
+        (self.lower_right.im - self.upper_left.im).abs()
+    }
 
-  pub fn left(&self) -> f64 {
-    self.upper_left.re
-  }
-  pub fn top(&self) -> f64 {
-    self.upper_left.im
-  }
+    pub fn left(&self) -> f64 {
+        self.upper_left.re
+    }
+    pub fn top(&self) -> f64 {
+        self.upper_left.im
+    }
 
-  pub fn x_delta(&self) -> f64 {
-    self.view_width() / ((self.size.width - 1) as f64)
-  }
-  pub fn y_delta(&self) -> f64 {
-    self.view_height() / ((self.size.height - 1) as f64)
-  }
+    pub fn x_delta(&self) -> f64 {
+        self.view_width() / ((self.size.width - 1) as f64)
+    }
+    pub fn y_delta(&self) -> f64 {
+        self.view_height() / ((self.size.height - 1) as f64)
+    }
 
-  pub fn complex_at(&self, col: u32, row: u32) -> Complex<f64> {
-    Complex::new(
-      self.left() + col as f64 * self.x_delta(),
-      self.top() - row as f64 * self.y_delta(),
-    )
-  }
+    pub fn complex_at(&self, col: u32, row: u32) -> Complex<f64> {
+        Complex::new(
+            self.left() + col as f64 * self.x_delta(),
+            self.top() - row as f64 * self.y_delta(),
+        )
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::*;
 
-  fn image() -> Image {
-    Image {
-      input_filename: "".to_string(),
-      output_filename: "".to_string(),
-      size: Size {
-        width: 512,
-        height: 384,
-      },
-      upper_left: Complex::new(-2.0, 1.2),
-      lower_right: Complex::new(1.2, -1.2),
+    fn image() -> Image {
+        Image {
+            input_filename: "".to_string(),
+            output_filename: "".to_string(),
+            size: Size {
+                width: 512,
+                height: 384,
+            },
+            upper_left: Complex::new(-2.0, 1.2),
+            lower_right: Complex::new(1.2, -1.2),
+        }
     }
-  }
 
-  #[test]
-  fn test_view_width() {
-    assert_eq!(3.2, image().view_width());
-  }
+    #[test]
+    fn test_view_width() {
+        assert_eq!(3.2, image().view_width());
+    }
 
-  #[test]
-  fn test_view_height() {
-    assert_eq!(2.4, image().view_height());
-  }
+    #[test]
+    fn test_view_height() {
+        assert_eq!(2.4, image().view_height());
+    }
 
-  #[test]
-  fn test_left() {
-    assert_eq!(-2.0, image().left());
-  }
+    #[test]
+    fn test_left() {
+        assert_eq!(-2.0, image().left());
+    }
 
-  #[test]
-  fn test_top() {
-    assert_eq!(1.2, image().top());
-  }
+    #[test]
+    fn test_top() {
+        assert_eq!(1.2, image().top());
+    }
 
-  #[test]
-  fn test_x_delta() {
-    assert_eq!(0.0062622309197651665, image().x_delta());
-  }
+    #[test]
+    fn test_x_delta() {
+        assert_eq!(0.0062622309197651665, image().x_delta());
+    }
 
-  #[test]
-  fn test_y_delta() {
-    assert_eq!(0.006266318537859007, image().y_delta());
-  }
+    #[test]
+    fn test_y_delta() {
+        assert_eq!(0.006266318537859007, image().y_delta());
+    }
 
-  #[test]
-  fn test_complex_at() {
-    assert_eq!(
-      Complex::new(-1.9686888454011742, 0.39791122715404703),
-      image().complex_at(5, 128)
-    );
-    assert_eq!(
-      Complex::new(-0.12133072407044998, 1.0809399477806787),
-      image().complex_at(300, 19)
-    );
-  }
+    #[test]
+    fn test_complex_at() {
+        assert_eq!(
+            Complex::new(-1.9686888454011742, 0.39791122715404703),
+            image().complex_at(5, 128)
+        );
+        assert_eq!(
+            Complex::new(-0.12133072407044998, 1.0809399477806787),
+            image().complex_at(300, 19)
+        );
+    }
 }

--- a/src/fractals/job.rs
+++ b/src/fractals/job.rs
@@ -3,6 +3,6 @@ use super::image::Image;
 
 #[derive(Debug, PartialEq)]
 pub struct Job {
-  pub image: Image,
-  pub color_scheme: ColorScheme,
+    pub image: Image,
+    pub color_scheme: Box<ColorScheme>,
 }

--- a/src/fractals/job.rs
+++ b/src/fractals/job.rs
@@ -1,7 +1,7 @@
 use super::color_scheme::ColorScheme;
 use super::image::Image;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct Job {
     pub image: Image,
     pub color_scheme: Box<ColorScheme>,

--- a/src/fractals/parser.rs
+++ b/src/fractals/parser.rs
@@ -5,188 +5,191 @@ use std::path::{Path, PathBuf};
 use yaml_rust::{Yaml, YamlLoader};
 
 use super::color_scheme::ColorScheme;
-use super::color_scheme::ColorScheme::*;
+use super::gray::{BlackOnWhite, Gray, WhiteOnBlack};
 use super::image::Image;
-use super::Job;
 use super::size::Size;
+use super::warp_pov::{Blue, Green, Red};
+use super::Job;
 
 pub fn parse(input_filename: &String) -> Job {
-  let mut file = File::open(input_filename).expect("Unable to open file");
-  let mut contents = String::new();
+    let mut file = File::open(input_filename).expect("Unable to open file");
+    let mut contents = String::new();
 
-  file
-    .read_to_string(&mut contents)
-    .expect("Unable to read file");
-  let docs = YamlLoader::load_from_str(&contents).unwrap();
-  parse_job(input_filename, &docs[0])
+    file.read_to_string(&mut contents)
+        .expect("Unable to read file");
+    let docs = YamlLoader::load_from_str(&contents).unwrap();
+    parse_job(input_filename, &docs[0])
 }
 
 pub fn parse_job(input_filename: &String, job_yaml: &Yaml) -> Job {
-  Job {
-    image: parse_image(input_filename, &job_yaml["image"]),
-    color_scheme: parse_color_scheme(&job_yaml["color_scheme"]),
-  }
+    Job {
+        image: parse_image(input_filename, &job_yaml["image"]),
+        color_scheme: parse_color_scheme(&job_yaml["color_scheme"]),
+    }
 }
 
 pub fn parse_image(input_filename: &String, image_yaml: &Yaml) -> Image {
-  Image {
-    input_filename: input_filename.clone(),
-    output_filename: build_output_filename(input_filename),
-    size: parse_size(&image_yaml["size"]),
-    upper_left: parse_complex(&image_yaml["upperLeft"]),
-    lower_right: parse_complex(&image_yaml["lowerRight"]),
-  }
+    Image {
+        input_filename: input_filename.clone(),
+        output_filename: build_output_filename(input_filename),
+        size: parse_size(&image_yaml["size"]),
+        upper_left: parse_complex(&image_yaml["upperLeft"]),
+        lower_right: parse_complex(&image_yaml["lowerRight"]),
+    }
 }
 
 fn build_output_filename(input_filename: &String) -> String {
-  let file_stem = Path::new(input_filename).file_stem().unwrap();
-  let mut output_filename = PathBuf::new();
-  output_filename.push("images");
-  output_filename.push(file_stem);
-  output_filename.set_extension("png");
-  output_filename.as_os_str().to_str().unwrap().to_string()
+    let file_stem = Path::new(input_filename).file_stem().unwrap();
+    let mut output_filename = PathBuf::new();
+    output_filename.push("images");
+    output_filename.push(file_stem);
+    output_filename.set_extension("png");
+    output_filename.as_os_str().to_str().unwrap().to_string()
 }
 
 fn parse_size(size: &Yaml) -> Size {
-  let size_str: &str = match size.as_str() {
-    Some(s) => s,
-    None => &"1024x768",
-  };
+    let size_str: &str = match size.as_str() {
+        Some(s) => s,
+        None => &"1024x768",
+    };
 
-  let size_vec: Vec<u32> = size_str
-    .split('x')
-    .map(|x| x.parse::<u32>().unwrap())
-    .collect();
+    let size_vec: Vec<u32> = size_str
+        .split('x')
+        .map(|x| x.parse::<u32>().unwrap())
+        .collect();
 
-  Size {
-    width: size_vec[0],
-    height: size_vec[1],
-  }
+    Size {
+        width: size_vec[0],
+        height: size_vec[1],
+    }
 }
 
 fn parse_complex(complex_value: &Yaml) -> Complex<f64> {
-  let complex_vec: Vec<f64> = complex_value
-    .as_str()
-    .unwrap()
-    .replace("i", "")
-    .split('+')
-    .map(|x| x.parse::<f64>().unwrap())
-    .collect();
+    let complex_vec: Vec<f64> = complex_value
+        .as_str()
+        .unwrap()
+        .replace("i", "")
+        .split('+')
+        .map(|x| x.parse::<f64>().unwrap())
+        .collect();
 
-  Complex::new(complex_vec[0], complex_vec[1])
+    Complex::new(complex_vec[0], complex_vec[1])
 }
 
-fn parse_color_scheme(color_scheme_yaml: &Yaml) -> ColorScheme {
-  match color_scheme_yaml["type"].as_str().unwrap() {
-    "BlackOnWhite" => Ok(BlackOnWhite),
-    "Blue" => Ok(Blue),
-    "Gray" => Ok(Gray),
-    "Green" => Ok(Green),
-    "Random" => Ok(Random),
-    "Red" => Ok(Red),
-    "WhiteOnBlack" => Ok(WhiteOnBlack),
-    _ => Err(()),
-  }.unwrap()
+fn parse_color_scheme(color_scheme_yaml: &Yaml) -> Box<ColorScheme> {
+    match color_scheme_yaml["type"].as_str().unwrap() {
+        "BlackOnWhite" => return Box::new(BlackOnWhite {}),
+        "Blue" => return Box::new(Blue {}),
+        "Gray" => return Box::new(Gray {}),
+        "Green" => return Box::new(Green {}),
+        // "Random" => Ok(Random {}),
+        "Red" => return Box::new(Red {}),
+        "WhiteOnBlack" => return Box::new(WhiteOnBlack {}),
+        _ => panic!("{:?} not a valid color scheme", color_scheme_yaml),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::super::escape_time::Iteration;
+    use super::*;
+    use ::image::Rgb;
 
-  #[test]
-  fn test_parse_complex() {
-    let parse = |s: &str| -> Complex<f64> { parse_complex(&Yaml::String(s.to_string())) };
+    #[test]
+    fn test_parse_complex() {
+        let parse = |s: &str| -> Complex<f64> { parse_complex(&Yaml::String(s.to_string())) };
 
-    assert_eq!(Complex::new(5.2, 3.8), parse("5.2+3.8i"));
-    assert_eq!(Complex::new(111.5, 876.222), parse("111.5+876.222i"));
-    assert_eq!(Complex::new(1.0, 2.0), parse("1+2i"));
-    assert_eq!(Complex::new(-5.2, 3.8), parse("-5.2+3.8i"));
-    assert_eq!(Complex::new(5.2, -3.8), parse("5.2+-3.8i"));
-    assert_eq!(Complex::new(-5.2, -3.8), parse("-5.2+-3.8i"));
-  }
+        assert_eq!(Complex::new(5.2, 3.8), parse("5.2+3.8i"));
+        assert_eq!(Complex::new(111.5, 876.222), parse("111.5+876.222i"));
+        assert_eq!(Complex::new(1.0, 2.0), parse("1+2i"));
+        assert_eq!(Complex::new(-5.2, 3.8), parse("-5.2+3.8i"));
+        assert_eq!(Complex::new(5.2, -3.8), parse("5.2+-3.8i"));
+        assert_eq!(Complex::new(-5.2, -3.8), parse("-5.2+-3.8i"));
+    }
 
+    #[test]
+    fn test_parse_size() {
+        let parse = |s: &str| -> Size { parse_size(&Yaml::String(s.to_string())) };
 
-  #[test]
-  fn test_parse_size() {
-    let parse = |s: &str| -> Size { parse_size(&Yaml::String(s.to_string())) };
+        assert_eq!(
+            Size {
+                width: 100,
+                height: 333
+            },
+            parse("100x333")
+        );
+        assert_eq!(
+            Size {
+                width: 9,
+                height: 12_345
+            },
+            parse("9x12345")
+        );
+    }
 
-    assert_eq!(
-      Size {
-        width: 100,
-        height: 333
-      },
-      parse("100x333")
-    );
-    assert_eq!(
-      Size {
-        width: 9,
-        height: 12_345
-      },
-      parse("9x12345")
-    );
-  }
-
-  #[test]
-  fn test_parse_image() {
-    let input = r#"
+    #[test]
+    fn test_parse_image() {
+        let input = r#"
       image:
         size: 512x384
         upperLeft: -2.0+1.2i
         lowerRight: 1.2+-1.2i
     "#;
-    let docs = YamlLoader::load_from_str(input).unwrap();
-    assert_eq!(
-      Image {
-        input_filename: "data/foobar.yml".to_string(),
-        output_filename: "images/foobar.png".to_string(),
-        size: Size {
-          width: 512,
-          height: 384
-        },
-        upper_left: Complex::new(-2.0, 1.2),
-        lower_right: Complex::new(1.2, -1.2),
-      },
-      parse_image(&String::from("data/foobar.yml"), &docs[0]["image"])
-    );
-  }
+        let docs = YamlLoader::load_from_str(input).unwrap();
+        assert_eq!(
+            Image {
+                input_filename: "data/foobar.yml".to_string(),
+                output_filename: "images/foobar.png".to_string(),
+                size: Size {
+                    width: 512,
+                    height: 384
+                },
+                upper_left: Complex::new(-2.0, 1.2),
+                lower_right: Complex::new(1.2, -1.2),
+            },
+            parse_image(&String::from("data/foobar.yml"), &docs[0]["image"])
+        );
+    }
 
-  #[test]
-  fn test_parse_image_without_size() {
-    let input = r#"
+    #[test]
+    fn test_parse_image_without_size() {
+        let input = r#"
       image:
         upperLeft: -2.0+1.2i
         lowerRight: 1.2+-1.2i
     "#;
-    let docs = YamlLoader::load_from_str(input).unwrap();
-    assert_eq!(
-      Size {
-        width: 1024,
-        height: 768
-      },
-      parse_image(&String::from("data/foobar.yml"), &docs[0]["image"]).size
-    );
-  }
+        let docs = YamlLoader::load_from_str(input).unwrap();
+        assert_eq!(
+            Size {
+                width: 1024,
+                height: 768
+            },
+            parse_image(&String::from("data/foobar.yml"), &docs[0]["image"]).size
+        );
+    }
 
-  #[test]
-  fn test_parse_color_scheme() {
-    let input = r#"
-      color_scheme:
-        type: BlackOnWhite
-    "#;
-    let docs = YamlLoader::load_from_str(input).unwrap();
-    assert_eq!(
-      ColorScheme::BlackOnWhite,
-      parse_color_scheme(&docs[0]["color_scheme"])
-    );
+    #[test]
+    fn test_parse_color_scheme() {
+        let input = r#"
+        color_scheme:
+          type: BlackOnWhite
+      "#;
+        let docs = YamlLoader::load_from_str(input).unwrap();
+        let cs = parse_color_scheme(&docs[0]["color_scheme"]);
+        assert_eq!(
+            Rgb([0, 0, 0]),
+            cs.color(Iteration::Inside { iterations: 200 })
+        );
 
-    let input = r#"
-      color_scheme:
-        type: Green
-    "#;
-    let docs = YamlLoader::load_from_str(input).unwrap();
-    assert_eq!(
-      ColorScheme::Green,
-      parse_color_scheme(&docs[0]["color_scheme"])
-    );
-  }
+        let input = r#"
+            color_scheme:
+              type: Green
+          "#;
+        let docs = YamlLoader::load_from_str(input).unwrap();
+        let cs = parse_color_scheme(&docs[0]["color_scheme"]);
+        assert_eq!(
+            Rgb([175, 255, 175]),
+            cs.color(Iteration::Outside { iterations: 432 })
+        );
+    }
 }

--- a/src/fractals/size.rs
+++ b/src/fractals/size.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, PartialEq)]
 pub struct Size {
-  pub width: u32,
-  pub height: u32,
+    pub width: u32,
+    pub height: u32,
 }

--- a/src/fractals/warp_pov.rs
+++ b/src/fractals/warp_pov.rs
@@ -3,74 +3,114 @@ use ::image::Rgb;
 use super::color_scheme::ColorScheme;
 use super::escape_time::Iteration;
 
-// Taken from http://warp.povusers.org/Mandelbrot/
-pub fn warp_pov(color_scheme: &ColorScheme, iter: Iteration) -> Result<Rgb<u8>, ()> {
-  let intensities = intensities(iter);
-  match color_scheme {
-    ColorScheme::Blue => Ok(permute_blue(intensities)),
-    ColorScheme::Green => Ok(permute_green(intensities)),
-    ColorScheme::Red => Ok(permute_red(intensities)),
-    &_ => Err(()),
-  }
+// Computations taken from http://warp.povusers.org/Mandelbrot/
+
+#[derive(Debug, PartialEq)]
+pub struct Blue {}
+
+#[derive(Debug, PartialEq)]
+pub struct Green {}
+
+#[derive(Debug, PartialEq)]
+pub struct Red {}
+
+impl ColorScheme for Blue {
+    fn color(&self, iter: Iteration) -> Rgb<u8> {
+        let (primary, secondary) = intensities(iter);
+        Rgb([secondary, secondary, primary])
+    }
 }
 
-fn permute_blue((primary, secondary): (u8, u8)) -> Rgb<u8> {
-  Rgb([secondary, secondary, primary])
+impl ColorScheme for Green {
+    fn color(&self, iter: Iteration) -> Rgb<u8> {
+        let (primary, secondary) = intensities(iter);
+        Rgb([secondary, primary, secondary])
+    }
 }
-fn permute_green((primary, secondary): (u8, u8)) -> Rgb<u8> {
-  Rgb([secondary, primary, secondary])
-}
-fn permute_red((primary, secondary): (u8, u8)) -> Rgb<u8> {
-  Rgb([primary, secondary, secondary])
+
+impl ColorScheme for Red {
+    fn color(&self, iter: Iteration) -> Rgb<u8> {
+        let (primary, secondary) = intensities(iter);
+        Rgb([primary, secondary, secondary])
+    }
 }
 
 fn intensities(iter: Iteration) -> (u8, u8) {
-  match iter {
-    Iteration::Inside { iterations: _ } => (0, 0),
-    Iteration::Outside { iterations } => {
-      let half_iterations = 512 / 2 - 1;
-      if iterations <= half_iterations {
-        (scale(1.max(iterations)), 0)
-      } else {
-        (1 * 255, scale(iterations - half_iterations))
-      }
+    match iter {
+        Iteration::Inside { .. } => (0, 0),
+        Iteration::Outside { iterations } => {
+            let half_iterations = 512 / 2 - 1;
+            if iterations <= half_iterations {
+                (scale(1.max(iterations)), 0)
+            } else {
+                (1 * 255, scale(iterations - half_iterations))
+            }
+        }
     }
-
-  }
 }
 
 fn scale(i: u32) -> u8 {
-  (2.0 * (i - 1) as f64 / 512 as f64 * 255.0) as u8
+    (2.0 * (i - 1) as f64 / 512 as f64 * 255.0) as u8
 }
-
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::*;
 
-  #[test]
-  fn test_scale() {
-    assert_eq!(0, scale(1));
-    assert_eq!(125, scale(127));
-    assert_eq!(126, scale(128));
-    // maybe a bit off
-    assert_eq!(253, scale(512));
-  }
+    #[test]
+    fn blue_is_primary() {
+        let cs = Blue {};
+        assert_eq!(
+            Rgb([175, 175, 255]),
+            cs.color(Iteration::Outside { iterations: 432 })
+        );
+    }
 
-  #[test]
-  fn test_intensities() {
-    assert_eq!((0, 0), intensities(Iteration::Outside { iterations: 1 }));
-    assert_eq!(
-      (253, 0),
-      intensities(Iteration::Outside { iterations: 255 })
-    );
-    assert_eq!(
-      (255, 0),
-      intensities(Iteration::Outside { iterations: 256 })
-    );
-    assert_eq!(
-      (255, 255),
-      intensities(Iteration::Outside { iterations: 512 })
-    );
-  }
+    #[test]
+    fn green_is_primary() {
+        let cs = Green {};
+        assert_eq!(
+            Rgb([175, 255, 175]),
+            cs.color(Iteration::Outside { iterations: 432 })
+        );
+    }
+
+    #[test]
+    fn red_is_primary() {
+        let cs = Red {};
+        assert_eq!(
+            Rgb([255, 175, 175]),
+            cs.color(Iteration::Outside { iterations: 432 })
+        );
+    }
+
+    #[test]
+    fn test_scale() {
+        assert_eq!(0, scale(1));
+        assert_eq!(125, scale(127));
+        assert_eq!(126, scale(128));
+        // maybe a bit off
+        assert_eq!(253, scale(512));
+    }
+
+    #[test]
+    fn test_intensities() {
+        assert_eq!((0, 0), intensities(Iteration::Outside { iterations: 1 }));
+        assert_eq!(
+            (253, 0),
+            intensities(Iteration::Outside { iterations: 255 })
+        );
+        assert_eq!(
+            (255, 175),
+            intensities(Iteration::Outside { iterations: 432 })
+        );
+        assert_eq!(
+            (255, 0),
+            intensities(Iteration::Outside { iterations: 256 })
+        );
+        assert_eq!(
+            (255, 255),
+            intensities(Iteration::Outside { iterations: 512 })
+        );
+    }
 }


### PR DESCRIPTION
`ColorScheme` is now a trait with a `color()` method.  Using boxed trait in the `Job` for the color scheme.