### PR TITLE
Issue 21 :: floating point colors

### DIFF
--- a/src/fractals/color_scheme.rs
+++ b/src/fractals/color_scheme.rs
@@ -5,6 +5,28 @@ use super::escape_time::Iteration;
 #[derive(Debug, PartialEq)]
 pub struct Random {}
 
+#[derive(Debug, PartialEq)]
+pub struct Color {
+  red: f32,
+  green: f32,
+  blue: f32,
+}
+
+impl Color {
+  pub fn new(red: f32, green: f32, blue: f32) -> Color {
+    Color { red, green, blue }
+  }
+
+  pub fn as_rgb(&self) -> Rgb<u8> {
+    let Color { red, green, blue } = self;
+    Rgb([
+      (red * 255.0) as u8,
+      (green * 255.0) as u8,
+      (blue * 255.0) as u8,
+    ])
+  }
+}
+
 pub trait ColorScheme: std::fmt::Debug {
   fn color(&self, iter: Iteration) -> Rgb<u8>;
 }

--- a/src/fractals/color_scheme.rs
+++ b/src/fractals/color_scheme.rs
@@ -28,5 +28,5 @@ impl Color {
 }
 
 pub trait ColorScheme: std::fmt::Debug {
-  fn color(&self, iter: Iteration) -> Rgb<u8>;
+  fn color(&self, iter: Iteration) -> Color;
 }

--- a/src/fractals/escape_time.rs
+++ b/src/fractals/escape_time.rs
@@ -2,22 +2,23 @@ use num_complex::Complex;
 
 #[derive(Debug, PartialEq)]
 pub enum Iteration {
-    Inside { iterations: u32 },
-    Outside { iterations: u32 },
+    Inside { iterations: u32, max_iterations: u32 },
+    Outside { iterations: u32, max_iterations: u32 },
 }
 
 pub fn iterate(c: &Complex<f64>) -> Iteration {
+    let max_iterations  = 512;
     let mut z = Complex::new(0.0, 0.0);
-    let mut iter = 0;
+    let mut iterations = 0;
 
-    while z.norm_sqr() < 4.0 && iter < 512 {
+    while z.norm_sqr() < 4.0 && iterations < max_iterations {
         z = z * z + c;
-        iter = iter + 1;
+        iterations = iterations + 1;
     }
-    if iter >= 512 {
-        Iteration::Inside { iterations: iter }
+    if iterations >= 512 {
+        Iteration::Inside { iterations, max_iterations }
     } else {
-        Iteration::Outside { iterations: iter }
+        Iteration::Outside { iterations, max_iterations }
     }
 }
 
@@ -28,11 +29,11 @@ mod tests {
     #[test]
     fn test_iterate_inside() {
         assert_eq!(
-            Iteration::Inside { iterations: 512 },
+            Iteration::Inside { iterations: 512, max_iterations: 512 },
             iterate(&Complex::new(0.0, 0.0))
         );
         assert_eq!(
-            Iteration::Inside { iterations: 512 },
+            Iteration::Inside { iterations: 512, max_iterations: 512 },
             iterate(&Complex::new(0.2, 0.5))
         );
     }
@@ -40,11 +41,11 @@ mod tests {
     #[test]
     fn test_iterate_outside() {
         assert_eq!(
-            Iteration::Outside { iterations: 1 },
+            Iteration::Outside { iterations: 1, max_iterations: 512 },
             iterate(&Complex::new(2.0, 2.0))
         );
         assert_eq!(
-            Iteration::Outside { iterations: 12 },
+            Iteration::Outside { iterations: 12, max_iterations: 512 },
             iterate(&Complex::new(0.2, 0.6))
         );
     }

--- a/src/fractals/gray.rs
+++ b/src/fractals/gray.rs
@@ -1,16 +1,14 @@
-use ::image::Rgb;
-
-use super::color_scheme::ColorScheme;
+use super::color_scheme::{Color, ColorScheme};
 use super::escape_time::Iteration;
 
 #[derive(Debug, PartialEq)]
 pub struct BlackOnWhite {}
 
 impl ColorScheme for BlackOnWhite {
-    fn color(&self, iter: Iteration) -> Rgb<u8> {
+    fn color(&self, iter: Iteration) -> Color {
         match iter {
-            Iteration::Inside { .. } => Rgb([0, 0, 0]),
-            Iteration::Outside { .. } => Rgb([255, 255, 255]),
+            Iteration::Inside { .. } => Color::new(0.0, 0.0, 0.0),
+            Iteration::Outside { .. } => Color::new(1.0, 1.0, 1.0),
         }
     }
 }
@@ -19,9 +17,9 @@ impl ColorScheme for BlackOnWhite {
 pub struct Gray {}
 
 impl ColorScheme for Gray {
-    fn color(&self, iter: Iteration) -> Rgb<u8> {
+    fn color(&self, iter: Iteration) -> Color {
         match iter {
-            Iteration::Inside { .. } => Rgb([0, 0, 0]),
+            Iteration::Inside { .. } => Color::new(0.0, 0.0, 0.0),
             Iteration::Outside { iterations } => gray_scale(iterations),
         }
     }
@@ -31,18 +29,17 @@ impl ColorScheme for Gray {
 pub struct WhiteOnBlack {}
 
 impl ColorScheme for WhiteOnBlack {
-    fn color(&self, iter: Iteration) -> Rgb<u8> {
+    fn color(&self, iter: Iteration) -> Color {
         match iter {
-            Iteration::Inside { .. } => Rgb([255, 255, 255]),
-            Iteration::Outside { .. } => Rgb([0, 0, 0]),
+            Iteration::Inside { .. } => Color::new(1.0, 1.0, 1.0),
+            Iteration::Outside { .. } => Color::new(0.0, 0.0, 0.0),
         }
     }
 }
 
-fn gray_scale(iterations: u32) -> Rgb<u8> {
-    let factor = (iterations as f64 / 512.0).sqrt();
-    let intensity = (factor * 255.0) as u8;
-    Rgb([intensity, intensity, intensity])
+fn gray_scale(iterations: u32) -> Color {
+    let intensity = (iterations as f32 / 512.0).sqrt();
+    Color::new(intensity, intensity, intensity)
 }
 
 #[cfg(test)]
@@ -71,14 +68,14 @@ mod tests {
           fn inside_always_black(iterations in 0u32..1024)  {
             let cs = BlackOnWhite {};
             let color = cs.color(outside(iterations));
-            prop_assert_eq!(Rgb([255, 255, 255]), color);
+            prop_assert_eq!(Color::new(1.0, 1.0, 1.0), color);
           }
 
           #[test]
           fn outside_always_white(iterations in 0u32..1024)  {
             let cs = BlackOnWhite {};
             let color = cs.color(inside(iterations));
-                prop_assert_eq!(Rgb([0, 0, 0]), color);
+                prop_assert_eq!(Color::new(0.0, 0.0, 0.0), color);
           }
         }
     }
@@ -86,7 +83,6 @@ mod tests {
     mod gray {
         use super::super::*;
         use super::*;
-        use ::image::Pixel;
         use proptest::prelude::*;
 
         proptest! {
@@ -94,7 +90,7 @@ mod tests {
             fn inside_always_black(iterations in 0u32..1024)  {
                 let cs = Gray {};
                 let color = cs.color(inside(iterations));
-                prop_assert_eq!(Rgb([0, 0, 0]), color);
+                prop_assert_eq!(Color::new(0.0, 0.0, 0.0), color);
             }
         }
 
@@ -103,16 +99,10 @@ mod tests {
             let cs = Gray {};
 
             let color = cs.color(outside(128));
-            let channels = color.channels();
-            assert_eq!(127, channels[0]);
-            assert_eq!(127, channels[1]);
-            assert_eq!(127, channels[2]);
+            assert_eq!(Color::new(0.5, 0.5, 0.5), color);
 
             let color = cs.color(outside(64));
-            let channels = color.channels();
-            assert_eq!(90, channels[0]);
-            assert_eq!(90, channels[1]);
-            assert_eq!(90, channels[2]);
+            assert_eq!(Color::new(0.35355338, 0.35355338, 0.35355338), color);
         }
     }
 
@@ -126,14 +116,14 @@ mod tests {
             fn inside_always_white(iterations in 0u32..1024)  {
                 let cs = WhiteOnBlack {};
                 let color = cs.color(inside(iterations));
-                prop_assert_eq!(Rgb([255, 255, 255]), color);
+                prop_assert_eq!(Color::new(1.0, 1.0, 1.0), color);
             }
 
             #[test]
             fn outside_always_black(iterations in 0u32..1024)  {
                 let cs = WhiteOnBlack {};
                 let color = cs.color(outside(iterations));
-                prop_assert_eq!(Rgb([0, 0, 0]), color);
+                prop_assert_eq!(Color::new(0.0, 0.0, 0.0), color);
             }
         }
     }

--- a/src/fractals/gray.rs
+++ b/src/fractals/gray.rs
@@ -20,7 +20,7 @@ impl ColorScheme for Gray {
     fn color(&self, iter: Iteration) -> Color {
         match iter {
             Iteration::Inside { .. } => Color::new(0.0, 0.0, 0.0),
-            Iteration::Outside { iterations } => gray_scale(iterations),
+            Iteration::Outside { iterations, .. } => gray_scale(iterations),
         }
     }
 }
@@ -47,15 +47,11 @@ mod tests {
     use super::*;
 
     fn inside(iterations: u32) -> Iteration {
-        Iteration::Inside {
-            iterations: iterations,
-        }
+        Iteration::Inside { iterations: iterations, max_iterations: 512, }
     }
 
     fn outside(iterations: u32) -> Iteration {
-        Iteration::Outside {
-            iterations: iterations,
-        }
+        Iteration::Outside { iterations: iterations, max_iterations: 512 }
     }
 
     mod black_on_white {

--- a/src/fractals/parser.rs
+++ b/src/fractals/parser.rs
@@ -178,7 +178,7 @@ mod tests {
         let cs = parse_color_scheme(&docs[0]["color_scheme"]);
         assert_eq!(
             Color::new(0.0, 0.0, 0.0),
-            cs.color(Iteration::Inside { iterations: 200 })
+            cs.color(Iteration::Inside { iterations: 200, max_iterations: 512 })
         );
 
         let input = r#"
@@ -189,7 +189,7 @@ mod tests {
         let cs = parse_color_scheme(&docs[0]["color_scheme"]);
         assert_eq!(
             Color::new(0.6875, 1.0, 0.6875),
-            cs.color(Iteration::Outside { iterations: 432 })
+            cs.color(Iteration::Outside { iterations: 432, max_iterations: 512 })
         );
     }
 }

--- a/src/fractals/parser.rs
+++ b/src/fractals/parser.rs
@@ -91,9 +91,9 @@ fn parse_color_scheme(color_scheme_yaml: &Yaml) -> Box<ColorScheme> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::color_scheme::Color;
     use super::super::escape_time::Iteration;
     use super::*;
-    use ::image::Rgb;
 
     #[test]
     fn test_parse_complex() {
@@ -177,7 +177,7 @@ mod tests {
         let docs = YamlLoader::load_from_str(input).unwrap();
         let cs = parse_color_scheme(&docs[0]["color_scheme"]);
         assert_eq!(
-            Rgb([0, 0, 0]),
+            Color::new(0.0, 0.0, 0.0),
             cs.color(Iteration::Inside { iterations: 200 })
         );
 
@@ -188,7 +188,7 @@ mod tests {
         let docs = YamlLoader::load_from_str(input).unwrap();
         let cs = parse_color_scheme(&docs[0]["color_scheme"]);
         assert_eq!(
-            Rgb([175, 255, 175]),
+            Color::new(0.6875, 1.0, 0.6875),
             cs.color(Iteration::Outside { iterations: 432 })
         );
     }

--- a/src/fractals/warp_pov.rs
+++ b/src/fractals/warp_pov.rs
@@ -36,23 +36,24 @@ impl ColorScheme for Red {
 fn intensities(iter: Iteration) -> (f32, f32) {
     match iter {
         Iteration::Inside { .. } => (0.0, 0.0),
-        Iteration::Outside { iterations } => outside_intensity(iterations),
+        Iteration::Outside {
+            iterations,
+            max_iterations,
+        } => outside_intensity(iterations, max_iterations),
     }
 }
 
-fn outside_intensity(iterations: u32) -> (f32, f32) {
-    let half_iterations = 512 / 2 - 1;
+fn outside_intensity(iterations: u32, max_iterations: u32) -> (f32, f32) {
+    let half_iterations = max_iterations / 2 - 1;
     if iterations <= half_iterations {
-        (scale(1.max(iterations)), 0.0)
+        (scale(1.max(iterations), max_iterations), 0.0)
     } else {
-        (1.0, scale(iterations - half_iterations))
+        (1.0, scale(iterations - half_iterations, max_iterations))
     }
 }
 
-fn scale(i: u32) -> f32 {
-    let adjusted_i = (i - 1) as f32;
-    let max_iterations = 512.0;
-    2.0 * adjusted_i / max_iterations
+fn scale(i: u32, max_iterations: u32) -> f32 {
+    2.0 * (i - 1) as f32 / max_iterations as f32
 }
 
 #[cfg(test)]
@@ -64,7 +65,10 @@ mod tests {
         let cs = Blue {};
         assert_eq!(
             Color::new(0.6875, 0.6875, 1.0),
-            cs.color(Iteration::Outside { iterations: 432 })
+            cs.color(Iteration::Outside {
+                iterations: 432,
+                max_iterations: 512
+            })
         );
     }
 
@@ -73,7 +77,10 @@ mod tests {
         let cs = Green {};
         assert_eq!(
             Color::new(0.6875, 1.0, 0.6875),
-            cs.color(Iteration::Outside { iterations: 432 })
+            cs.color(Iteration::Outside {
+                iterations: 432,
+                max_iterations: 512
+            })
         );
     }
 
@@ -82,39 +89,57 @@ mod tests {
         let cs = Red {};
         assert_eq!(
             Color::new(1.0, 0.6875, 0.6875),
-            cs.color(Iteration::Outside { iterations: 432 })
+            cs.color(Iteration::Outside {
+                iterations: 432,
+                max_iterations: 512
+            })
         );
     }
 
     #[test]
     fn test_scale() {
-        assert_eq!(0.0, scale(1));
-        assert_eq!(0.4921875, scale(127));
-        assert_eq!(0.49609375, scale(128));
-        assert_eq!(0.98828125, scale(254));
+        assert_eq!(0.0, scale(1, 512));
+        assert_eq!(0.4921875, scale(127, 512));
+        assert_eq!(0.49609375, scale(128, 512));
+        assert_eq!(0.98828125, scale(254, 512));
     }
 
     #[test]
     fn test_intensities() {
         assert_eq!(
             (0.0, 0.0),
-            intensities(Iteration::Outside { iterations: 1 })
+            intensities(Iteration::Outside {
+                iterations: 1,
+                max_iterations: 512
+            })
         );
         assert_eq!(
             (0.9921875, 0.0),
-            intensities(Iteration::Outside { iterations: 255 })
+            intensities(Iteration::Outside {
+                iterations: 255,
+                max_iterations: 512
+            })
         );
         assert_eq!(
             (1.0, 0.6875),
-            intensities(Iteration::Outside { iterations: 432 })
+            intensities(Iteration::Outside {
+                iterations: 432,
+                max_iterations: 512
+            })
         );
         assert_eq!(
             (1.0, 0.0),
-            intensities(Iteration::Outside { iterations: 256 })
+            intensities(Iteration::Outside {
+                iterations: 256,
+                max_iterations: 512
+            })
         );
         assert_eq!(
             (1.0, 1.0),
-            intensities(Iteration::Outside { iterations: 512 })
+            intensities(Iteration::Outside {
+                iterations: 512,
+                max_iterations: 512
+            })
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,10 @@ fn main() {
     for row in 0..job.image.size.height {
         for col in 0..job.image.size.width {
             let iter = iterate(&job.image.complex_at(col, row));
+            let color = job.color_scheme.color(iter);
+            let pixel_color = color.as_rgb();
             let pixel = image.get_pixel_mut(col, row);
-            *pixel = job.color_scheme.color(iter);
+            *pixel = pixel_color;
         }
     }
     image.save(&job.image.output_filename).unwrap();


### PR DESCRIPTION
Color schemes return floating-point values for red, green, blue.  Image processing turns them into integers.